### PR TITLE
change kc to kubectl

### DIFF
--- a/_docs/020-getting-started-on-gke.md
+++ b/_docs/020-getting-started-on-gke.md
@@ -56,7 +56,7 @@ kubectl config current-context
 Remove the GKE default request of 0.1 CPU's per container which limits how many containers your cluster is allowed to schedule (effectively 10 per vCPU).
 
 ```
-kc delete limitrange limits
+kubectl delete limitrange limits
 ```
 
 ### install helm


### PR DESCRIPTION
I assume this is using a locally defined synonym for kubectl