### PR TITLE
Add a Content Security Policy

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,3 +1,4 @@
+<meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; frame-src 'self' https://www.youtube.com/">
 <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon-32x32.png">
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon-16x16.png">


### PR DESCRIPTION
A Content Security Policy (CSP) is a best practice for websites. The
policy restricts which hosts are allowd to provide resources for the
page.

This CSP blocks all resource not hosted on projectriff.io, with the
exception of the youtube embed.