### PR TITLE
Create a 'Getting Started' landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-remote_theme: "mmistakes/minimal-mistakes"
+remote_theme: "mmistakes/minimal-mistakes@4.13.0"
 plugins:
   - jekyll-remote-theme
   - jekyll-redirect-from

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -15,9 +15,9 @@ main:
 # documentation links
 docs:
   - title: Getting Started
+    url: /docs/getting-started/
     children:
       - title: "on GKE"
-        url: /docs/getting-started-with-knative-riff-on-gke/
+        url: /docs/getting-started/gke/
       - title: "on minikube"
-        url: /docs/getting-started-with-knative-riff-on-minikube/
-
+        url: /docs/getting-started/minikube/

--- a/_docs/020-getting-started.md
+++ b/_docs/020-getting-started.md
@@ -1,0 +1,22 @@
+---
+layout: doc
+title: "Getting started"
+permalink: /docs/getting-started/
+excerpt: "How to run Knative using **riff**"
+header:
+  overlay_image: /images/sunrise.jpg
+  overlay_filter: 0.3
+  overlay_color: "#333"
+redirect_from:
+- /docs/
+---
+
+# Pick your environment
+
+While riff should work in any certified Kubernetes environment, we actively test with these environments:
+
+{% for doc in site.docs %}
+  {% if doc.categories contains 'getting-started' %}
+    {% include archive-single.html post=doc title=doc.short_title %}
+  {% endif %}
+{% endfor %}

--- a/_docs/021-getting-started-gke.md
+++ b/_docs/021-getting-started-gke.md
@@ -1,14 +1,18 @@
 ---
+layout: doc
 title: "Getting started on GKE"
-permalink: /docs/getting-started-with-knative-riff-on-gke/
+short_title: on GKE
+permalink: /docs/getting-started/gke/
 excerpt: "How to run Knative using **riff** on Google Kubernetes Engine"
 header:
   overlay_image: /images/gke.png
   overlay_filter: 0.4
   overlay_color: "#555"
 redirect_from:
-  - /docs/
-  - /docs/getting-started-on-gke/
+- /docs/getting-started-on-gke/
+- /docs/getting-started-with-knative-riff-on-gke/
+categories:
+- getting-started
 ---
 
 # Getting started on GKE

--- a/_docs/022-getting-started-minikube.md
+++ b/_docs/022-getting-started-minikube.md
@@ -1,15 +1,20 @@
 ---
+layout: doc
 title: "Getting started running on Minikube"
-permalink: /docs/getting-started-with-knative-riff-on-minikube/
+short_title: on Minikube
+permalink: /docs/getting-started/minikube/
 excerpt: "How to run Knative using **riff** on Minikube"
 header:
   overlay_image: /images/minikube2.png
   overlay_filter: 0.4
   overlay_color: "#555"
 redirect_from:
-  - /docs/getting-started-on-minikube/
-  - /docs/getting-started-on-docker-ce-edge-for-mac/
-  - /docs/getting-started-on-docker-ce-edge-for-windows/
+- /docs/getting-started-on-minikube/
+- /docs/getting-started-with-knative-riff-on-minikube/
+- /docs/getting-started-on-docker-ce-edge-for-mac/
+- /docs/getting-started-on-docker-ce-edge-for-windows/
+categories:
+- getting-started
 ---
 
 # Getting started on Minikube

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -1,7 +1,14 @@
 {% comment %}
   from https://github.com/mmistakes/minimal-mistakes/blob/dcdbba835ccec00303cef87cbc1efe5c89cf5ed6/_includes/archive-single.html
-  modified to allow for youtube video embeds
+  modified to allow for:
+  - youtube video embeds
+  - custom post inlucde arg
+  - custom title
 {% endcomment %}
+
+{% if include.post %}
+  {% assign post = include.post %}
+{% endif %}
 
 {% if post.header.teaser %}
   {% capture teaser %}{{ post.header.teaser }}{% endcapture %}
@@ -9,7 +16,9 @@
   {% assign teaser = site.teaser %}
 {% endif %}
 
-{% if post.id %}
+{% if include.title %}
+  {% assign title = include.title %}
+{% elsif post.id %}
   {% assign title = post.title | markdownify | remove: "<p>" | remove: "</p>" %}
 {% else %}
   {% assign title = post.title %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,0 +1,5 @@
+---
+layout: single
+---
+
+{{ content }}


### PR DESCRIPTION
The excerpts could use another pass in this new context.

- pinned the theme version since master was erroring
- add `/docs/getting-started/`
  - includes links and a summary of each getting started guide
  - managed automatically by the 'getting-started' doc category
  - redirect `/docs/` here until we have more docs
- updated current doc links to be `/docs/getting-started/{env}`
  - retained redirects for previous URLs

Fixes #42