### PR TITLE
Fix node-square samples by providing artifact.

### DIFF
--- a/_docs/021-getting-started-gke.md
+++ b/_docs/021-getting-started-gke.md
@@ -246,6 +246,7 @@ This step will pull the source code for a function from a GitHub repo, build a c
 riff function create square \
   --git-repo https://github.com/projectriff-samples/node-square \
   --image gcr.io/$GCP_PROJECT_ID/square:v2 \
+  --artifact square.js \
   --verbose
 ```
 

--- a/_docs/022-getting-started-minikube.md
+++ b/_docs/022-getting-started-minikube.md
@@ -160,6 +160,7 @@ This step will pull the source code for a function from a GitHub repo, build a c
 riff function create square \
   --git-repo https://github.com/projectriff-samples/node-square  \
   --image $DOCKER_ID/square:v2 \
+  --artifact square.js \
   --verbose
 ```
 

--- a/_docs/023-getting-started-docker-for-mac.md
+++ b/_docs/023-getting-started-docker-for-mac.md
@@ -136,6 +136,7 @@ This step will pull the source code for a function from a GitHub repo, build a c
 riff function create square \
   --git-repo https://github.com/projectriff-samples/node-square  \
   --image $DOCKER_ID/square:v2 \
+  --artifact square.js \
   --verbose
 ```
 


### PR DESCRIPTION
I broke the getting started docs when i cleaned up the sample in https://github.com/projectriff-samples/node-square/pull/4. This fixes the docs to be explicit about the `square.js` artifact. 