### PR TITLE
URL Cleanup

### DIFF
--- a/_docs/022-getting-started-minikube.md
+++ b/_docs/022-getting-started-minikube.md
@@ -187,7 +187,7 @@ riff service invoke square --json -- -w '\n' -d 8
 #### result
 
 ```
-curl http://192.168.64.46:31380/ -H 'Host: square.default.example.com' -H 'Content-Type: application/json' -w '\n' -d 8
+curl https://192.168.64.46:31380/ -H 'Host: square.default.example.com' -H 'Content-Type: application/json' -w '\n' -d 8
 64
 ```
 

--- a/_includes/archive-single.html
+++ b/_includes/archive-single.html
@@ -25,7 +25,7 @@
 {% endif %}
 
 <div class="{{ include.type | default: "list" }}__item">
-  <article class="archive__item" itemscope itemtype="http://schema.org/CreativeWork">
+  <article class="archive__item" itemscope itemtype="https://schema.org/CreativeWork">
     {% if include.type == "grid" and teaser %}
       <div class="archive__item-teaser">
         <img src=

--- a/_posts/2018-04-06-announcing-riff-0-0-6.md
+++ b/_posts/2018-04-06-announcing-riff-0-0-6.md
@@ -126,11 +126,11 @@ We’ve updated the http-gateway to validate topics and return an HTTP 404 error
 
 ```
 $ riff publish --input nosuchrifftopic --data "404 From Message"
-Posting to http://192.168.39.148:32508/messages/nosuchrifftopic
+Posting to https://192.168.39.148:32508/messages/nosuchrifftopic
 could not find Riff topic 'nosuchrifftopic'
 
 riff publish --input nosuchrifftopic --data "404 From Request" --reply
-Posting to http://192.168.39.148:32508/requests/nosuchrifftopic
+Posting to https://192.168.39.148:32508/requests/nosuchrifftopic
 could not find Riff topic 'nosuchrifftopic'
 ```
 

--- a/_posts/2018-08-09-announcing-riff-0-1-1-on-Knative.md
+++ b/_posts/2018-08-09-announcing-riff-0-1-1-on-Knative.md
@@ -49,6 +49,6 @@ riff service invoke hello -- -w '\n' -d stranger
 The output should look something like this:
 
 ```
-curl http://192.168.64.31:32380 -H 'Host: hello.default.example.com' -w '\n' -d stranger
+curl https://192.168.64.31:32380 -H 'Host: hello.default.example.com' -w '\n' -d stranger
 hello stranger
 ```

--- a/_posts/2018-08-31-announcing-riff-0-1-2-on-Knative.md
+++ b/_posts/2018-08-31-announcing-riff-0-1-2-on-Knative.md
@@ -165,7 +165,7 @@ Invoke the function to send posts to hello.
 ```sh
 riff service invoke random -- -w '\n' \
   -H 'Content-Type:application/json' \
-  -d '{"url":"http://hello.default.svc.cluster.local"}'
+  -d '{"url":"https://hello.default.svc.cluster.local"}'
 ```
 
 The kail log of the hello function from above should show the numbers as they are generated
@@ -195,7 +195,7 @@ riff service subscribe hello --input squares
 ```sh
 riff service invoke random -- -w '\n' \
   -H 'Content-Type:application/json' \
-  -d '{"url":"http://numbers-channel.default.svc.cluster.local"}'
+  -d '{"url":"https://numbers-channel.default.svc.cluster.local"}'
 ```
 
 Now the hello function should show the output of square and hello chained together.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://rbenv.org/ (200) with 1 occurrences could not be migrated:  
   ([https](https://rbenv.org/) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://192.168.39.148:32508/messages/nosuchrifftopic (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.39.148:32508/messages/nosuchrifftopic ([https](https://192.168.39.148:32508/messages/nosuchrifftopic) result ConnectTimeoutException).
* [ ] http://192.168.39.148:32508/requests/nosuchrifftopic (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.39.148:32508/requests/nosuchrifftopic ([https](https://192.168.39.148:32508/requests/nosuchrifftopic) result ConnectTimeoutException).
* [ ] http://192.168.64.31:32380 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.64.31:32380 ([https](https://192.168.64.31:32380) result ConnectTimeoutException).
* [ ] http://192.168.64.46:31380/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://192.168.64.46:31380/ ([https](https://192.168.64.46:31380/) result ConnectTimeoutException).
* [ ] http://hello.default.svc.cluster.local (UnknownHostException) with 1 occurrences migrated to:  
  https://hello.default.svc.cluster.local ([https](https://hello.default.svc.cluster.local) result UnknownHostException).
* [ ] http://numbers-channel.default.svc.cluster.local (UnknownHostException) with 1 occurrences migrated to:  
  https://numbers-channel.default.svc.cluster.local ([https](https://numbers-channel.default.svc.cluster.local) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://schema.org/CreativeWork with 1 occurrences migrated to:  
  https://schema.org/CreativeWork ([https](https://schema.org/CreativeWork) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost:31380/ with 1 occurrences
* http://www.w3.org/2000/svg with 1 occurrences