### PR TITLE
Cleanup doc headers for java invoker

### DIFF
--- a/docs/v0.4/invokers/java.md
+++ b/docs/v0.4/invokers/java.md
@@ -4,8 +4,6 @@ title: Java Function Invoker
 sidebar_label: Java
 ---
 
-## Creating Java functions for riff
-
 Java functions will be invoked using a [Java Function Invoker](https://github.com/projectriff/java-function-invoker) that is provided by riff when you build the function.
 
 The _Java Function Invoker_ is a Spring Boot application which will locate your function based on configuration settings, and invoke the function for each request.
@@ -14,11 +12,11 @@ The riff function support for the Java language relies on function code being wr
 
 The implementation can be provided as a plain Java class or as part of a Spring Boot app.
 
-### Creating a Spring Boot based function
+## Creating a Spring Boot based function
 
 Begin by creating a new project using [Spring Initializr](start.spring.io).  You can select either `Maven Project` or `Gradle Project` as the project type but the language must be `Java`. Pick a name for your project and any dependencies that your function requires. The final step is to download the generated zip file and extracting the contents.
 
-#### Adding functions
+### Adding functions
 
 You can now add a `@Bean` providing the function implementation. It can either be added as a separate `@Configuration` source file or for simple functions just add it to the main application file. Here we add the `upper` function to the main `@SpringBootApplication` source file:
 
@@ -46,7 +44,7 @@ public class UpperApplication {
 }
 ```
 
-#### Building the Spring Boot based function
+### Building the Spring Boot based function
 
 You can build your function either from local source or from source committed to a GitHub repository. For local build use:
 
@@ -64,7 +62,7 @@ The `--handler` option is the name of the `@Bean` that was used for the function
 
 > NOTE: If you haven't specified a default image prefix when setting the credentials then you need to provide an _&#8209;&#8209;image_ option for the function create command.
 
-#### Running a Spring Boot based function locally
+### Running a Spring Boot based function locally
 
 If you would like to run your Spring Boot based function locally you can include web support when creating the project with Spring Initializr. Add the _Function_ dependency plus either _Spring Web Starter_ or _Spring Reactive Web_. 
 
@@ -86,7 +84,7 @@ If your application contains multiple functions you need to provide the bean nam
 curl localhost:8080/lower -H 'Content-Type: text/plain' -w '\n' -d hello
 ```
 
-### Creating a plain Java function
+## Creating a plain Java function
 
 You can create function using plain Java code, without having to depend on Spring Boot for configuration. This requires some more work when setting things up. You need to create your own build scripts using either Maven or Gradle. There are no required dependencies but you can provide dependencies that your function requires. You can find an example here: https://github.com/projectriff-samples/java-hello
 
@@ -105,7 +103,7 @@ public class Hello implements Function<String, String> {
 }
 ```
 
-#### Building the plain Java function
+### Building the plain Java function
 
 Just as for Spring Boot based functions you can build your plain Java function either from local source or from source committed to a GitHub repository. Here we will only show the build from the GitHub repo:
 
@@ -115,7 +113,7 @@ riff function create hello --git-repo https://github.com/projectriff-samples/jav
 
 The `--handler` option is the fully qualified name of the class that provides the function implementation.
 
-### Deploying and invoking the function
+## Deploying and invoking the function
 
 To deploy your function you need to select a runtime. The two options currently available are `core` and `knative` and we will select `knative`for this example:
 


### PR DESCRIPTION
- remove leading header (it conflicts with the page title)
- promote all subheaders up one level (the subnav is more meaningful)