### PR TITLE
Polish

### DIFF
--- a/docs/v0.3.md
+++ b/docs/v0.3.md
@@ -1,10 +1,38 @@
 ---
 id: v0.3
-title: v0.3.x
+title: riff v0.3.x
 sidebar_label: v0.3.x
 ---
 
-## riff v0.3.x
+<style>
+.mainContainer {
+  -webkit-animation: hideonload 2s;
+     -moz-animation: hideonload 2s;
+      -ms-animation: hideonload 2s;
+       -o-animation: hideonload 2s;
+          animation: hideonload 2s;
+}
+@keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-moz-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-webkit-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-ms-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-o-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+</style>
 
 [Get started with riff v0.3.x](./v0.3/getting-started.md)
 

--- a/docs/v0.4/cli.md
+++ b/docs/v0.4/cli.md
@@ -4,6 +4,38 @@ title: CLI
 sidebar_label: CLI
 ---
 
-## yada yada
+<style>
+.mainContainer {
+  -webkit-animation: hideonload 2s;
+     -moz-animation: hideonload 2s;
+      -ms-animation: hideonload 2s;
+       -o-animation: hideonload 2s;
+          animation: hideonload 2s;
+}
+@keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-moz-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-webkit-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-ms-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@-o-keyframes hideonload {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+</style>
 
-yada
+[riff CLI](./cli/riff.md)
+
+<script type="text/javascript">
+  window.location.href = '/docs/v0.4/cli/riff';
+</script>

--- a/docs/v0.4/getting-started.md
+++ b/docs/v0.4/getting-started.md
@@ -6,18 +6,18 @@ sidebar_label: Pick your environment
 
 While riff should work in any certified Kubernetes environment, we actively test with these environments:
 
-## [on GKE](getting-started/gke.md)
+## [GKE](getting-started/gke.md)
 
 How to run riff on Google Kubernetes Engine
 
-## [on Minikube](getting-started/minikube.md)
+## [Minikube](getting-started/minikube.md)
 
 How to run riff on Minikube
 
-## [on Docker for Mac](getting-started/docker-for-mac.md)
+## [Docker for Mac](getting-started/docker-for-mac.md)
 
 How to run riff on Docker Community Edition for Mac
 
-## [on Docker for Windows](getting-started/docker-for-windows.md)
+## [Docker for Windows](getting-started/docker-for-windows.md)
 
 How to run riff on Docker Community Edition for Windows

--- a/docs/v0.4/getting-started/docker-for-mac.md
+++ b/docs/v0.4/getting-started/docker-for-mac.md
@@ -42,7 +42,7 @@ kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceac
 helm init --wait --service-account tiller
 ```
 
-> Please see the [Helm documentation](https://helm.sh/docs/using_helm/#securing-your-helm-installation) for additional Helm security configuration.
+> NOTE: Please see the [Helm documentation](https://helm.sh/docs/using_helm/#securing-your-helm-installation) for additional Helm security configuration.
 
 ## install the riff CLI
 
@@ -234,7 +234,7 @@ curl http://localhost:8080/ -w '\n' \
 64
 ```
 
-> Note that unlike Knative, the Core runtime will not scale deployments down to zero.
+> NOTE: unlike Knative, the Core runtime will not scale deployments down to zero.
 
 ## cleanup
 

--- a/docs/v0.4/invokers.md
+++ b/docs/v0.4/invokers.md
@@ -1,8 +1,10 @@
 ---
-id: v0.4
-title: riff v0.4.x
-sidebar_label: v0.4.x
+id: invokers
+title: Invokers
+sidebar_label: Invokers
 ---
+
+<!-- TODO convert into a listing of each invoker -->
 
 <style>
 .mainContainer {
@@ -34,9 +36,8 @@ sidebar_label: v0.4.x
 }
 </style>
 
-[Get started with riff v0.4.x](./v0.4/getting-started.md)
+[riff CLI](./invokers/command.md)
 
 <script type="text/javascript">
-  window.location.href = '/docs/v0.4/getting-started';
+  window.location.href = '/docs/v0.4/invokers/command';
 </script>
-

--- a/docs/v0.4/invokers/java.md
+++ b/docs/v0.4/invokers/java.md
@@ -16,7 +16,7 @@ The implementation can be provided as a plain Java class or as part of a Spring 
 
 Begin by creating a new project using [Spring Initializr](start.spring.io).  You can select either `Maven Project` or `Gradle Project` as the project type but the language must be `Java`. Pick a name for your project and any dependencies that your function requires. The final step is to download the generated zip file and extracting the contents.
 
-### Adding functions
+### adding functions
 
 You can now add a `@Bean` providing the function implementation. It can either be added as a separate `@Configuration` source file or for simple functions just add it to the main application file. Here we add the `uppercase` function to the main `@SpringBootApplication` source file:
 
@@ -44,7 +44,7 @@ public class UppercaseApplication {
 }
 ```
 
-### Building the Spring Boot based function
+### building the Spring Boot based function
 
 You can build your function either from local source or from source committed to a GitHub repository.
 
@@ -66,7 +66,7 @@ The `--handler` option is the name of the `@Bean` that was used for the function
 
 > NOTE: If you haven't specified a default image prefix when setting the credentials then you need to provide an _&#8209;&#8209;image_ option for the function create command.
 
-### Running a Spring Boot based function locally
+### running a Spring Boot based function locally
 
 If you would like to run your Spring Boot based function locally you can include web support when creating the project with Spring Initializr. Add the _Function_ dependency plus either _Spring Web Starter_ or _Spring Reactive Web_.
 
@@ -107,7 +107,7 @@ public class Hello implements Function<String, String> {
 }
 ```
 
-### Building the plain Java function
+### building the plain Java function
 
 Just as for Spring Boot based functions you can build your plain Java function either from local source or from source committed to a GitHub repository. Here we will only show the build from the GitHub repo:
 

--- a/docs/v0.4/runtimes.md
+++ b/docs/v0.4/runtimes.md
@@ -1,8 +1,10 @@
 ---
-id: v0.4
-title: riff v0.4.x
-sidebar_label: v0.4.x
+id: runtimes
+title: Runtimes
+sidebar_label: Runtimes
 ---
+
+<!-- TODO convert into a listing of each runtime -->
 
 <style>
 .mainContainer {
@@ -34,9 +36,8 @@ sidebar_label: v0.4.x
 }
 </style>
 
-[Get started with riff v0.4.x](./v0.4/getting-started.md)
+[riff CLI](./runtimes/core.md)
 
 <script type="text/javascript">
-  window.location.href = '/docs/v0.4/getting-started';
+  window.location.href = '/docs/v0.4/runtimes/core';
 </script>
-

--- a/docs/v0.4/runtimes/core.md
+++ b/docs/v0.4/runtimes/core.md
@@ -47,7 +47,7 @@ square   function   square   square-deployer   Ready    10s
 
 Since the core runtime does not provide Ingress, a connection to the cluster must be established before the function can be invoked. For production workloads, installing and configuring ingress is recommended but is outside the scope of this doc. For development, use `kubectl port-forward` to map a local port to the deployer.
 
-### Setup port forwarding
+### setup port forwarding
 
 From the deployer listing (`riff core deployer list`), get the service name for the function, in this case `square-deployer`. In a new terminal, run:
 
@@ -64,7 +64,7 @@ The port forward command establishes a connection to the deployer's service on l
 
 > NOTE: the port forwarding needs to be reestablished when a new instance of the function is rolled out.
 
-### Call the function
+### call the workload
 
 ```sh
 curl localhost:8080 -v -w '\n' -H 'Content-Type: application/json' -d 7

--- a/docs/v0.4/runtimes/knative.md
+++ b/docs/v0.4/runtimes/knative.md
@@ -45,7 +45,7 @@ NAME     TYPE       REF      HOST                         STATUS   AGE
 square   function   square   square.default.example.com   Ready    11s
 ```
 
-### call the deployer
+### call the workload
 
 How to invoke the function depends on the type of cluster and how it was configured. After getting the host set it as `HOST` and then pick the `INGRESS` definition that is appropriate for the cluster.
 


### PR DESCRIPTION
Normalize headings:
- level 2 is sentence case
- level 3+ is lower case

Normalize redirect pages:
- hide content for 2 seconds to allow for the script based redirect to
  fire without flashing the page's content
- add landing pages for invokers and runtimes, redirecting to a specific
  pages, should be converting into a listing down the road
- convert the cli landing page into a redirect to the riff command