### PR TITLE
Remove custom admission plugins for Minikube

### DIFF
--- a/docs/v0.3/getting-started/minikube.md
+++ b/docs/v0.3/getting-started/minikube.md
@@ -41,10 +41,9 @@ Installing [Docker Community Edition](https://store.docker.com/search?type=editi
 ## create a Minikube cluster
 
 ```sh
-minikube start --memory=4096 --cpus=4 \
---kubernetes-version=v1.14.1 \
---vm-driver=hyperkit \
---extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+minikube start \
+  --memory=4096 --cpus=4 \
+  --vm-driver=hyperkit
 ```
 
 To use the kvm2 driver for Linux specify `--vm-driver=kvm2`. Omitting the `--vm-driver` option will use the default driver.

--- a/docs/v0.4/getting-started/minikube.md
+++ b/docs/v0.4/getting-started/minikube.md
@@ -32,11 +32,9 @@ Installing [Docker Community Edition](https://store.docker.com/search?type=editi
 ## Create a Minikube cluster
 
 ```sh
-minikube start --memory=4096 --cpus=4 \
---kubernetes-version=v1.14.6 \
---vm-driver=hyperkit \
---bootstrapper=kubeadm \
---extra-config=apiserver.enable-admission-plugins="LimitRanger,NamespaceExists,NamespaceLifecycle,ResourceQuota,ServiceAccount,DefaultStorageClass,MutatingAdmissionWebhook"
+minikube start \
+  --memory=4096 --cpus=4 \
+  --vm-driver=hyperkit
 ```
 
 To use the kvm2 driver for Linux specify `--vm-driver=kvm2`. Omitting the `--vm-driver` option will use the default driver.


### PR DESCRIPTION
By specifying any admission plugins we are actually disabling plugins
that have been enabled by default in newer versions of Kubernetes.

Plugins we specified that are not enabled by default:
- NamespaceExists

Plugins enabled by default that we're missing:
- TaintNodesByCondition
- Priority
- DefaultTolerationSeconds
- PersistentVolumeClaimResize
- ValidatingAdmissionWebhook

This change also removes the --kubernetes-version flag and instead uses
the latest stable version by default.