### PR TITLE
Npm run publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: install
+install:
+	cd website && npm install
+
+.PHONY: start
+start:
+	cd website && npm start
+
+.PHONY: build
+build:
+	cd website && npm run build
+
+.PHONY: publish
+publish:
+	cd website && npm run publish

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+GIT_USER ?= $(shell git config --get github.user)
+USE_SSH ?= true
+
 .PHONY: install
 install:
 	cd website && npm install
@@ -12,4 +15,7 @@ build:
 
 .PHONY: publish
 publish:
+	@export GIT_USER
+	@export USE_SSH
+	@env | grep -e "GIT_USER" -e "USE_SSH"
 	cd website && npm run publish

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,5 +2,5 @@
 
 [build]
   base = "website/"
-  publish = "website/build/riff/"
+  publish = "website/build/projectriff.io/"
   command = "npm run build"

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,8 @@
   "license": "Apache-2.0",
   "scripts": {
     "start": "docusaurus-start",
-    "build": "docusaurus-build"
+    "build": "docusaurus-build",
+    "publish": "docusaurus-publish"
   },
   "dependencies": {
     "docusaurus": "^1.12.0"

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -6,12 +6,14 @@
 
 const siteConfig = {
 
-  projectName: 'riff',
+  // for gh-pages publishing using `npm run publish`
+  projectName: 'projectriff.io',
   organizationName: 'projectriff',
+  cname: 'projectriff.io',
+
   title: 'riff is for functions',
   tagline: '',
 
-  cname: 'projectriff.io',
   url: 'https://projectriff.io',
   baseUrl: '/',
 


### PR DESCRIPTION
Enable easy publishing to gh-pages branch with "make publish"
Calls docusaurus-publish feature, see [docs](https://docusaurus.io/docs/en/publishing#using-github-pages) for configuration  .