### PR TITLE
Automatically publish from master to gh-pages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
       with:
-        node-version: 8
+        node-version: 10
     - run: npm install
       working-directory: website
     - run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,26 @@
+name: Publish to gh-pages
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 8
+    - run: npm install
+      working-directory: website
+    - run: |
+        git config --global user.email "${GIT_USER}@users.noreply.github.com"
+        git config --global user.name "Github Actions"
+        echo "machine github.com login ${GIT_USER} password ${GITHUB_TOKEN}" > ~/.netrc
+        npm run publish
+      working-directory: website
+      env:
+        GIT_USER: ${{secrets.GH_USER}}
+        GITHUB_TOKEN: ${{secrets.GH_PERSONAL_ACCESS_TOKEN}}


### PR DESCRIPTION
Use GitHub actions with a custom personal access token to build the
latest commit from master and publish to gh-pages.

It seems the stock GITHUB_TOKEN secret provided by GitHub Actions is
unable to push a commit. I'd love to be wrong here.

As a test, [this build](https://github.com/projectriff/projectriff.io/runs/211195149), created [this commit](https://github.com/projectriff/projectriff.io/commit/df95c12a58dc544c086cd2c921a083f0204008d7) on the gh-pages branch.