### PR TITLE
Core service names match deployer names

### DIFF
--- a/docs/v0.5/getting-started/docker-for-mac.md
+++ b/docs/v0.5/getting-started/docker-for-mac.md
@@ -225,8 +225,8 @@ After the deployer is created, you can see the service name by listing deployers
 riff core deployers list
 ```
 ```
-NAME         TYPE       REF      SERVICE               STATUS   AGE
-k8s-square   function   square   k8s-square-deployer   Ready    16s
+NAME         TYPE       REF      URL                                           STATUS   AGE
+k8s-square   function   square   http://k8s-square.default.svc.cluster.local   Ready    35s
 ```
 
 ### invoke the function
@@ -234,7 +234,7 @@ k8s-square   function   square   k8s-square-deployer   Ready    16s
 In a separate terminal, start port-forwarding to the ClusterIP service created by the deployer.
 
 ```sh
-kubectl port-forward service/k8s-square-deployer 8080:80
+kubectl port-forward service/k8s-square 8080:80
 ```
 ```
 Forwarding from 127.0.0.1:8080 -> 8080

--- a/docs/v0.5/getting-started/docker-for-windows.md
+++ b/docs/v0.5/getting-started/docker-for-windows.md
@@ -263,12 +263,11 @@ riff core deployer create k8s-square --function-ref square --tail
 After the deployer is created, you can see the service name by listing deployers.
 
 ```sh
-riff core deployer list
+riff core deployers list
 ```
-
 ```
-NAME         TYPE       REF      SERVICE               STATUS   AGE
-k8s-square   function   square   k8s-square-deployer   Ready    21s
+NAME         TYPE       REF      URL                                           STATUS   AGE
+k8s-square   function   square   http://k8s-square.default.svc.cluster.local   Ready    35s
 ```
 
 ### invoke the function
@@ -276,7 +275,7 @@ k8s-square   function   square   k8s-square-deployer   Ready    21s
 In a separate terminal, start port-forwarding to the ClusterIP service created by the deployer.
 
 ```sh
-kubectl port-forward service/k8s-square-deployer 8080:80
+kubectl port-forward service/k8s-square 8080:80
 ```
 ```
 Forwarding from 127.0.0.1:8080 -> 8080

--- a/docs/v0.5/getting-started/gke.md
+++ b/docs/v0.5/getting-started/gke.md
@@ -326,8 +326,8 @@ After the deployer is created, you can see the service name by listing deployers
 riff core deployers list
 ```
 ```
-NAME         TYPE       REF      SERVICE               STATUS   AGE
-k8s-square   function   square   k8s-square-deployer   Ready    37s
+NAME         TYPE       REF      URL                                           STATUS   AGE
+k8s-square   function   square   http://k8s-square.default.svc.cluster.local   Ready    35s
 ```
 
 ### invoke the function
@@ -335,7 +335,7 @@ k8s-square   function   square   k8s-square-deployer   Ready    37s
 In a separate terminal, start port-forwarding to the ClusterIP service created by the deployer.
 
 ```sh
-kubectl port-forward service/k8s-square-deployer 8080:80
+kubectl port-forward service/k8s-square 8080:80
 ```
 ```
 Forwarding from 127.0.0.1:8080 -> 8080

--- a/docs/v0.5/getting-started/minikube.md
+++ b/docs/v0.5/getting-started/minikube.md
@@ -243,8 +243,8 @@ After the deployer is created, you can see the service name by listing deployers
 riff core deployers list
 ```
 ```
-NAME         TYPE       REF      SERVICE               STATUS   AGE
-k8s-square   function   square   k8s-square-deployer   Ready    7s
+NAME         TYPE       REF      URL                                           STATUS   AGE
+k8s-square   function   square   http://k8s-square.default.svc.cluster.local   Ready    35s
 ```
 
 ### invoke the function
@@ -252,7 +252,7 @@ k8s-square   function   square   k8s-square-deployer   Ready    7s
 In a separate terminal, start port-forwarding to the ClusterIP service created by the deployer.
 
 ```sh
-kubectl port-forward service/k8s-square-deployer 8080:80
+kubectl port-forward service/k8s-square 8080:80
 ```
 ```
 Forwarding from 127.0.0.1:8080 -> 8080


### PR DESCRIPTION
Fixes v0.5 docs to match core runtime service names and deployer lists.
