### PR TITLE
Fix annoying version dropdown scrollbar jank

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -92,3 +92,9 @@ from https://github.com/facebook/flux/blob/abb5c0c43fa6d7c017ebef613776c3fd91db5
   font-size: 24px;
   color: #24292e;
 }
+
+/* navbar version dropdown */
+.navGroups > .navGroup:first-of-type > .navGroupCategoryTitle {
+  font-size: 15px;
+  border-bottom:solid 1px #555;
+}


### PR DESCRIPTION
[preview](https://deploy-preview-200--projectriff.netlify.com/docs/v0.5/cli/riff)

The arrow next to the version in the sidebar would descend when the sidebar scrollbar is visible.
E.g. [here](https://projectriff.io/docs/v0.5/cli/riff)

The extra border below the text also distinguishes the version dropdown visually from the rest of the sidebar.

| before   | after    |
| :------- | :------ |
|![Screenshot 2020-02-05 at 13 30 59](https://user-images.githubusercontent.com/849592/73849915-adc9e880-4822-11ea-8ec1-80ecc669ecfa.png)|![Screenshot 2020-02-05 at 14 21 59](https://user-images.githubusercontent.com/849592/73850477-a7883c00-4823-11ea-9c3d-38b5d472decb.png)|